### PR TITLE
Fix zombienet

### DIFF
--- a/zombienet.toml
+++ b/zombienet.toml
@@ -1,6 +1,6 @@
 [relaychain]
 default_command = "polkadot"
-chain = "dev"
+chain = "rococo-local"
 
 [[relaychain.nodes]]
 name = "alice"
@@ -11,6 +11,6 @@ ws_port = 9944
 id = 1000
 
 [parachains.collator]
-name = "alice"
+name = "bob"
 ws_port = 9988
 command = "parachain-template-node"


### PR DESCRIPTION
Any idea why it is using `dev`?

Wait 11 blocks on the relay and then there should be para blocks:

![Screenshot 2024-08-07 at 22 55 15](https://github.com/user-attachments/assets/e921e28e-7179-4b5e-8f58-486b4b98257c)
