### PR TITLE
Correct zombienet config

### DIFF
--- a/zombienet.toml
+++ b/zombienet.toml
@@ -7,10 +7,15 @@ name = "alice"
 validator = true
 ws_port = 9944
 
+[[relaychain.nodes]]
+name = "bob"
+validator = true
+ws_port = 9955
+
 [[parachains]]
 id = 1000
 
 [parachains.collator]
-name = "bob"
+name = "charlie"
 ws_port = 9988
 command = "parachain-template-node"


### PR DESCRIPTION
We need at least two relaychain validators.

The fix upstream will be done in https://github.com/paritytech/polkadot-sdk/pull/5279