### PR TITLE
Add a zombienet smoke test

### DIFF
--- a/.github/actions/ubuntu-dependencies/action.yml
+++ b/.github/actions/ubuntu-dependencies/action.yml
@@ -5,7 +5,6 @@ runs:
   using: "composite"
   steps:
     - name: Rust compilation prerequisites (Ubuntu)
-      if: contains(matrix.os, 'ubuntu')
       run: |
         sudo apt update
         sudo apt install -y \

--- a/.github/tests/zombienet-smoke-test.zndsl
+++ b/.github/tests/zombienet-smoke-test.zndsl
@@ -1,0 +1,22 @@
+Description: Smoke test of the network
+Network: ../../zombienet.toml
+Creds: config
+
+alice: is up
+bob: is up
+charlie: is up
+
+alice: log line matches "Imported #[0-9]+" within 20 seconds
+bob: log line matches "Imported #[0-9]+" within 20 seconds
+
+alice: parachain 1000 is registered within 60 seconds
+alice: parachain 1000 block height is at least 10 within 200 seconds
+
+alice: count of log lines matching "err=" is 0 within 10 seconds
+alice: count of log lines matching "Error" is 0 within 10 seconds
+
+bob: count of log lines matching "err=" is 0 within 10 seconds
+bob: count of log lines matching "Error" is 0 within 10 seconds
+
+charlie: count of log lines matching "err=" is 0 within 10 seconds
+charlie: count of log lines matching "Error" is 0 within 10 seconds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,7 @@ jobs:
       # Check the `test-zombienet` workflow for a parachain smoke test.
       - name: Check that the node starts up
         run: |
-          ./target/debug/parachain-template-node --dev 2>&1 | tee out.txt &
-          until curl -s '127.0.0.1:9944'; do sleep 5; done
-          until cat out.txt | grep -s "💤 Idle"; do sleep 5; done
-        shell: bash
-        timeout-minutes: 5
+          ./target/debug/parachain-template-node --help
 
   build-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  ci:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -45,31 +45,12 @@ jobs:
         run: SKIP_WASM_BUILD=1 cargo doc --workspace --no-deps
         timeout-minutes: 15
 
-  run-node:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-
-      - if: contains(matrix.os, 'ubuntu')
-        uses: ./.github/actions/free-disk-space
-      - if: contains(matrix.os, 'ubuntu')
-        uses: ./.github/actions/ubuntu-dependencies
-      - if: contains(matrix.os, 'macos')
-        uses: ./.github/actions/macos-dependencies
-
-      - name: Build the node individually in release mode
-        run: cargo build --package parachain-template-node --release
-        timeout-minutes: 90
-
       # This test only makes sure the node got successfully built
-      # and can be executed without issues.
-      # A test including a relaychain will be done separately.
+      # and can be executed without issues on Ubuntu and macOS.
+      # Check the `test-zombienet` workflow for a parachain smoke test.
       - name: Check that the node starts up
         run: |
-          ./target/release/parachain-template-node --dev 2>&1 | tee out.txt &
+          ./target/debug/parachain-template-node --dev 2>&1 | tee out.txt &
           until curl -s '127.0.0.1:9944'; do sleep 5; done
           until cat out.txt | grep -s "💤 Idle"; do sleep 5; done
         shell: bash

--- a/.github/workflows/test-zombienet.yml
+++ b/.github/workflows/test-zombienet.yml
@@ -13,21 +13,14 @@ concurrency:
 
 jobs:
   test-zombienet:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     env:
       POLKADOT_VERSION: stable2407
     steps:
       - uses: actions/checkout@v4
 
-      - if: contains(matrix.os, 'ubuntu')
-        uses: ./.github/actions/free-disk-space
-      - if: contains(matrix.os, 'ubuntu')
-        uses: ./.github/actions/ubuntu-dependencies
-      - if: contains(matrix.os, 'macos')
-        uses: ./.github/actions/macos-dependencies
+      - uses: ./.github/actions/free-disk-space
+      - uses: ./.github/actions/ubuntu-dependencies
 
       - name: Build the node individually in release mode
         run: cargo build --package parachain-template-node --release

--- a/.github/workflows/test-zombienet.yml
+++ b/.github/workflows/test-zombienet.yml
@@ -1,0 +1,49 @@
+name: Test Zombienet
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-zombienet:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    env:
+      POLKADOT_VERSION: stable2407
+    steps:
+      - uses: actions/checkout@v4
+
+      - if: contains(matrix.os, 'ubuntu')
+        uses: ./.github/actions/free-disk-space
+      - if: contains(matrix.os, 'ubuntu')
+        uses: ./.github/actions/ubuntu-dependencies
+      - if: contains(matrix.os, 'macos')
+        uses: ./.github/actions/macos-dependencies
+
+      - name: Build the node individually in release mode
+        run: cargo build --package parachain-template-node --release
+        timeout-minutes: 90
+
+      - name: Download relaychain binaries
+        run: |
+          wget --no-verbose https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-${{ env.POLKADOT_VERSION }}/polkadot
+          wget --no-verbose https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-${{ env.POLKADOT_VERSION }}/polkadot-prepare-worker
+          wget --no-verbose https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-${{ env.POLKADOT_VERSION }}/polkadot-execute-worker
+          chmod +x ./polkadot*
+        working-directory: ./target/release
+
+      - name: Run zombienet tests
+        run: |
+          export PATH="./target/release:$PATH"
+          npx --yes @zombienet/cli --provider native test .github/tests/zombienet-smoke-test.zndsl
+        shell: bash
+        timeout-minutes: 10


### PR DESCRIPTION
- Introduce a zombienet-based smoke test for the parachain.
- Remove the separate `run-node` job.
  - Building in release mode is tested in the new zombienet job, and making sure the binary is properly executable on both Ubuntu and macOS can be done in the other job that builds the binary in debug mode.
- The zombienet test is run on Ubuntu only at the moment. macOS can be added once we have [this](https://github.com/paritytech/polkadot-sdk/issues/802) - it is currently number two on the [developer wishlist](https://github.com/paritytech/polkadot-sdk/issues/3900). Alternative would be to build `polkadot-sdk` from scratch but I don't think we want this in this template.
- Along the way, found [a bug](https://github.com/paritytech/zombienet/issues/1843) in zombienet, proposed a fix.