### PR TITLE
add rust-toolchain info

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+[toolchain]
+channel = "1.84.1"
+components = [
+    "cargo",
+    "clippy",
+    "rust-analyzer",
+    "rust-src",
+    "rust-std",
+    "rustc",
+    "rustfmt",
+]
+targets = ["wasm32-unknown-unknown"]
+profile = "default"


### PR DESCRIPTION
Solves #33 

Added rust-toolchain.toml for default rust version with the version information taken from `polkadot-sdk/.github/env`.