### PR TITLE
fix/release: skip pallet revive fixtures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: ./.github/actions/ubuntu-dependencies
 
       - name: Build the template
-        run: cargo build --workspace --all-features --locked --profile production
+        run: SKIP_PALLET_REVIVE_FIXTURES=1 cargo build --workspace --all-features --locked --profile production
         timeout-minutes: 90
 
       - name: Upload the binaries


### PR DESCRIPTION
We must skip pallet revive fixtures building - not relevant to parachain template.